### PR TITLE
Fix dns dependency

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -3,7 +3,8 @@ open Mirage
 let main =
   let packages = [
     package "mirage-qubes";
-    package "dns" ~sublibs:["mirage"];
+    package "dns";
+    package "mirage-dns";
   ] in
   foreign
     ~packages


### PR DESCRIPTION
It seems `dns.mirage` has been moved to `mirage-dns` :-)